### PR TITLE
Fix for parsing boolean values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hckrnews/objects",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hckrnews/objects",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "license": "LGPL-3.0",
             "dependencies": {
                 "@hckrnews/error": "^0.3.8",
@@ -2686,9 +2686,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "17.0.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-            "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
+            "version": "17.0.38",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+            "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
             "dev": true
         },
         "node_modules/@types/prettier": {
@@ -3965,9 +3965,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.142",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.142.tgz",
-            "integrity": "sha512-ea8Q1YX0JRp4GylOmX4gFHIizi0j9GfRW4EkaHnkZp0agRCBB4ZGeCv17IEzIvBkiYVwfoKVhKZJbTfqCRdQdg==",
+            "version": "1.4.143",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.143.tgz",
+            "integrity": "sha512-2hIgvu0+pDfXIqmVmV5X6iwMjQ2KxDsWKwM+oI1fABEOy/Dqmll0QJRmIQ3rm+XaoUa/qKrmy5h7LSTFQ6Ldzg==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -4357,7 +4357,7 @@
         "node_modules/eslint-module-utils/node_modules/p-locate": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
             "dev": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
@@ -4369,7 +4369,7 @@
         "node_modules/eslint-module-utils/node_modules/p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
             "dev": true,
             "engines": {
                 "node": ">=4"
@@ -4378,7 +4378,7 @@
         "node_modules/eslint-module-utils/node_modules/path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "dev": true,
             "engines": {
                 "node": ">=4"
@@ -8183,7 +8183,7 @@
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -8291,7 +8291,7 @@
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
@@ -8413,7 +8413,7 @@
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -12024,9 +12024,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "17.0.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-            "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
+            "version": "17.0.38",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+            "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
             "dev": true
         },
         "@types/prettier": {
@@ -13012,9 +13012,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.142",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.142.tgz",
-            "integrity": "sha512-ea8Q1YX0JRp4GylOmX4gFHIizi0j9GfRW4EkaHnkZp0agRCBB4ZGeCv17IEzIvBkiYVwfoKVhKZJbTfqCRdQdg==",
+            "version": "1.4.143",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.143.tgz",
+            "integrity": "sha512-2hIgvu0+pDfXIqmVmV5X6iwMjQ2KxDsWKwM+oI1fABEOy/Dqmll0QJRmIQ3rm+XaoUa/qKrmy5h7LSTFQ6Ldzg==",
             "dev": true
         },
         "emittery": {
@@ -13417,7 +13417,7 @@
                 "p-locate": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
                     "dev": true,
                     "requires": {
                         "p-limit": "^1.1.0"
@@ -13426,13 +13426,13 @@
                 "p-try": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
                     "dev": true
                 },
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
                     "dev": true
                 }
             }
@@ -16189,7 +16189,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true
         },
         "object-inspect": {
@@ -16264,7 +16264,7 @@
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "requires": {
                 "wrappy": "1"
@@ -16353,7 +16353,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true
         },
         "path-key": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@hckrnews/objects",
     "description": "Create valid JavaScript objects",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "author": {
         "name": "Pieter Wigboldus",
         "url": "https://hckr.news/"

--- a/src/__tests__/parse-object.spec.js
+++ b/src/__tests__/parse-object.spec.js
@@ -135,4 +135,24 @@ describe('Test objects.js parse', () => {
             },
         });
     });
+
+    it('It should handle a boolean with a string false', () => {
+        const input = {
+            a: '101',
+            b: 'false',
+            subSchema: {
+                a: '103',
+                b: 'false'
+            },
+        };
+
+        expect(Test.parse(input)).toEqual({
+            a: 101,
+            b: false,
+            subSchema: {
+                a: 103,
+                b: false,
+            },
+        });
+    });
 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -68,7 +68,7 @@ export default class Parser {
             return [key, subParser.parseObject(value)];
         }
 
-        if (Type === Boolean && value?.constructor === String) {
+        if (Type === Boolean && value.constructor === String) {
             if (value === '1') {
                 return [key, true];
             }

--- a/src/parser.js
+++ b/src/parser.js
@@ -69,7 +69,7 @@ export default class Parser {
         }
 
         if (Type === Boolean && value.constructor === String) {
-            if (value === '1') {
+            if (String(value) === '1') {
                 return [key, true];
             }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -67,6 +67,15 @@ export default class Parser {
             const subParser = new Parser({ schema: Type });
             return [key, subParser.parseObject(value)];
         }
+
+        if (Type === Boolean && value?.constructor === String) {
+            if (value === '1') {
+                return [key, true];
+            }
+
+            return [key, String(value).toLowerCase() === 'true'];
+        }
+
         return Type ? [key, new Type(value).valueOf()] : [key, value];
     }
 }


### PR DESCRIPTION
If you send it as a string

e.g. 

schema: 
```javascript
{
  test: Boolean
}
```

data:
```javascript
{
  test: 'false'
}
```

It will now return false if the type is Boolean and the value is 'false' or '0'